### PR TITLE
fix memory leak in ctl_growk()

### DIFF
--- a/src/ctl.c
+++ b/src/ctl.c
@@ -627,6 +627,8 @@ ctl_growk(unsigned partition)
 		if (ctl_stats.narenas != narenas_auto)
 			idalloc(arenas_old);
 	}
+	if (ctl_stats.narenas != narenas_auto)
+		idalloc(ctl_stats.arenas);
 	ctl_stats.arenas = astats;
 	ctl_stats.narenas++;
 


### PR DESCRIPTION
Fixes the exponential memory usage growth when creating a large number
of extended arenas in libmemkind.

Already fixed in jemalloc 4.0, so there's no need to merge it upstream.
